### PR TITLE
Meta Tags - Update description

### DIFF
--- a/altspace-vr/index.yml
+++ b/altspace-vr/index.yml
@@ -7,7 +7,7 @@ brand: windows
 
 metadata:
   title: Welcome to AltspaceVR! # Required; page title displayed in search results. Include the brand. < 60 chars.
-  description: description # Required; article description that is displayed in search results. < 160 chars.
+  description: Explore the expanding world of VR events with AltspaceVR. # Required; article description that is displayed in search results. < 160 chars.
   services: mixed-reality 
   ms.service: mixed-reality #Required; service per approved list. service slug assigned to your service by ACOM.
   ms.topic: hub-page # Required


### PR DESCRIPTION
The description meta tag is causing social media cards that derive from metatags to appear incomplete as they are displaying the string literal 'description'. 

Example from Discord:

![image](https://user-images.githubusercontent.com/52220496/112920589-21315800-90be-11eb-9e1e-5eb158aa0c68.png)

Copied the string from the `summary` value in this same file to `description` for a quick fix. Feel free to update with a more contextual string as appropriate.